### PR TITLE
udapte kuebernetesVersion as per CaaS Dev 2 after ERE upgarde to 5.5.1

### DIFF
--- a/internal/acceptance_test/resource_caas_cluster_blueprint_test.go
+++ b/internal/acceptance_test/resource_caas_cluster_blueprint_test.go
@@ -26,7 +26,7 @@ const (
 	cpCount             = "1"
 	workerName          = "worker1"
 	workerCount         = "1"
-	kubernetesVersion   = "1.23.10-hpe2"
+	kubernetesVersion   = "1.23.13-hpe2"
 	apiURLCbp           = "https://mcaas.intg.hpedevops.net/mcaas"
 	siteNameCBp         = "FTC"
 	//apiURLCbp           = "https://mcaas.us1.greenlake-hpe.com/mcaas"


### PR DESCRIPTION
Rally : [DE16071](https://rally1.rallydev.com/#/316931633904ud/iterationstatus?detail=/defect/685168848293)